### PR TITLE
Support FULLTEXT keys in table statements

### DIFF
--- a/main/dumpscanner.l
+++ b/main/dumpscanner.l
@@ -126,6 +126,7 @@ bool is_anonymized() {
 <ST_TABLE>json.*                        { DUPOUT return TYPE; }
 <ST_TABLE>PRIMARY\ KEY.*                { DUPOUT }
 <ST_TABLE>UNIQUE\ KEY.*                 { DUPOUT }
+<ST_TABLE>FULLTEXT\ KEY.*               { DUPOUT }
 <ST_TABLE>KEY.*                         { DUPOUT }
 <ST_TABLE>CONSTRAINT.*                  { DUPOUT }
 <ST_TABLE>DELIMITER.*                   { DUPOUT }


### PR DESCRIPTION
I had an issue with a table that contains a FULLTEXT index. The tool was not able to parse the `CREATE TABLE` definition and failed.

This PR adds support for such indexes.