### PR TITLE
Added substring support for field actions

### DIFF
--- a/main/configparser.y
+++ b/main/configparser.y
@@ -91,7 +91,7 @@ static bool is_valid_json_path(const char *path);
 /* 
  * Flex tokens
  */
-%token SECRET STATS TABLES YES NO FIXEDNULL FIXED FIXEDQUOTED FIXEDUNQUOTED TEXTHASH EMAILHASH INTHASH TRUNCATE KEY APPENDKEY PREPENDKEY EQ LEFT RIGHT PYPATH PYSCRIPT PYDEF JSON PATH SEPARATEDBY
+%token SECRET STATS TABLES YES NO FIXEDNULL FIXED FIXEDQUOTED FIXEDUNQUOTED TEXTHASH EMAILHASH INTHASH TRUNCATE KEY APPENDKEY PREPENDKEY EQ LEFT RIGHT PYPATH PYSCRIPT PYDEF JSON PATH SEPARATEDBY SUBSTRING
 %token <strval> STRING IDENTIFIER
 %token <shortval> LENGTH
 
@@ -204,6 +204,8 @@ fieldaction:
   emailhash separated |
   inthash |
   inthash separated |
+  substring |
+  substring separated |
   key |
   appendkey |
   prependkey |
@@ -256,6 +258,13 @@ inthash:
                     workinfos.type = AM_INTHASH;
                     workinfos.len=(unsigned short)$2;
                  }
+
+substring:
+  SUBSTRING LENGTH {
+                    workinfos.type = AM_SUBSTRING;
+                    workinfos.len=(unsigned short)$2;
+                  }
+
 key:
   KEY {
         workinfos.type = AM_KEY;

--- a/main/configscanner.l
+++ b/main/configscanner.l
@@ -60,6 +60,7 @@ fixed                   { return FIXED; }
 texthash                { return TEXTHASH; }
 emailhash               { return EMAILHASH; }
 inthash                 { return INTHASH; }
+substring		{ return SUBSTRING; }
 truncate                { return TRUNCATE; }
 key                     { return KEY; }
 appendkey               { return APPENDKEY; }

--- a/main/myanon.c
+++ b/main/myanon.c
@@ -200,6 +200,11 @@ anonymized_res_st anonymize_token(bool quoted, anon_base_st *config, char *token
         res_st.len = MIN(SHA256_DIGEST_SIZE, config->len);
         make_readable_hash((unsigned char *)worktoken, worktokenlen, &res_st, '1', '9');
         break;
+    case AM_SUBSTRING:
+        res_st.len = MIN(worktokenlen, config->len);
+        DEBUG_MSG("%d, %d, %d", worktokenlen, config->len, res_st.len)
+        mystrcpy((char *)&(res_st.data[0]), worktoken, res_st.len + 1);
+        break;
 
 #ifdef HAVE_PYTHON
     case AM_PY:

--- a/main/myanon.h
+++ b/main/myanon.h
@@ -103,6 +103,7 @@ typedef enum anon_type
     AM_KEY,
     AM_APPENDKEY,
     AM_PREPENDKEY,
+    AM_SUBSTRING,
     AM_JSON,
 #ifdef HAVE_PYTHON
     AM_PY,

--- a/tests/test_substring.conf
+++ b/tests/test_substring.conf
@@ -1,0 +1,9 @@
+# Config file for test1.sql
+secret = 'lapin'
+stats  = 'no'
+
+tables = {
+   `minimal_table` = {
+     `minimal_col`      = substring 5
+    }
+}

--- a/tests/test_substring.sql
+++ b/tests/test_substring.sql
@@ -1,0 +1,49 @@
+-- MySQL dump 10.13  Distrib 8.3.0, for macos14.2 (arm64)
+--
+-- Host: 127.0.0.1    Database: minimal
+-- ------------------------------------------------------
+-- Server version	8.3.0
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!50503 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+
+--
+-- Table structure for table `minimal_table`
+--
+
+DROP TABLE IF EXISTS `minimal_table`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `minimal_table` (
+  `minimal_col` varchar(1024) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `minimal_table`
+--
+
+LOCK TABLES `minimal_table` WRITE;
+/*!40000 ALTER TABLE `minimal_table` DISABLE KEYS */;
+INSERT INTO `minimal_table` VALUES ('minimaal zo veel'),('🥳');
+/*!40000 ALTER TABLE `minimal_table` ENABLE KEYS */;
+UNLOCK TABLES;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+-- Dump completed on 2024-08-13 15:47:46


### PR DESCRIPTION
We have a use case where we need the start of a field, but due to privacy issues do not want the entire field to be anonymized. So I've proposed a substring method, that takes an argument for how many chars it will copy.

This could also have been done with the new python implementation, but we had issues with mismatching python version on our build agent vs actual data node. 

Not sure if you appreciate the direct proposal, but no harm in asking, right?