### PR TITLE
CRLF line endings syntax error

### DIFF
--- a/main/configscanner.l
+++ b/main/configscanner.l
@@ -90,7 +90,7 @@ regex                   { return REGEX;}
                           COPYSTR
                           return IDENTIFIER;
                         }
-[ \t]
+[ \t\r]
 \n                      { config_line_nb ++; }
 #.*
 .                       {


### PR DESCRIPTION
Hi, I had an issue today where a config file with CRLF line endings would result in this error message:

```bash
]onfig parsing error at line 2: Syntax error - Unexpected [
```

(The `]` at the beginning is part of it, no idea how that can happen.)

I think this is very similar to #46 so I tested it and the fix seems to work. I'm not a C programmer though, take this with a big grain of salt.

Thank you for this program, it's very useful!

Oneliner to generate a test config file:
```bash
printf "secret = 'test'\r\nstats = 'no'\r\ntables = {\r\n  `users` = {\r\n    `name` = texthash 10\r\n  }\r\n}\r\n" > test_crlf.conf
```