### PR TITLE
Fix truncate semicolon handling

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,7 @@ EXTRA_DIST = $(top_srcdir)/uthash/uthash.h \
              $(top_srcdir)/debian/rules \
              $(top_srcdir)/debian/source/format
 
-TULIST = test1 test1-insert-ignore null-example appendkey prependkey issue29 issue52 test_substring appendindex prependindex test_regex complex
+TULIST = test1 test1-insert-ignore null-example appendkey prependkey issue29 issue52 issue_semicolon_truncate test_substring appendindex prependindex test_regex complex
 PYTULIST = test_python test_large_python test_large_python_2 test_row_context
 PYTHON_SUPPORT = @PYTHON_SUPPORT@
 

--- a/main/dumpscanner.l
+++ b/main/dumpscanner.l
@@ -157,6 +157,8 @@ static void set_working_table() {
 <ST_TRUNCATE>\n                   { DUPOUT dump_line_nb++; }
 <ST_TRUNCATE>.                    { DUPOUT }
 
+<ST_TRUNCATE_SKIP>_binary\ '(\\.|[^'\\])*'  { /* consume silently */ }
+<ST_TRUNCATE_SKIP>'(\\.|[^'\\])*'           { /* consume silently */ }
 <ST_TRUNCATE_SKIP>;               { BEGIN(ST_TRUNCATE); }
 <ST_TRUNCATE_SKIP>\n              { dump_line_nb++; }
 <ST_TRUNCATE_SKIP>.               { /* consume silently */ }

--- a/tests/issue_semicolon_truncate.conf
+++ b/tests/issue_semicolon_truncate.conf
@@ -1,0 +1,6 @@
+secret = 'test-secret'
+stats  = 'no'
+
+tables = {
+   `truncate_semicolon_case` = truncate
+}

--- a/tests/issue_semicolon_truncate.sql
+++ b/tests/issue_semicolon_truncate.sql
@@ -1,0 +1,19 @@
+DROP TABLE IF EXISTS `truncate_semicolon_case`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `truncate_semicolon_case` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `note` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `truncate_semicolon_case`
+--
+
+LOCK TABLES `truncate_semicolon_case` WRITE;
+/*!40000 ALTER TABLE `truncate_semicolon_case` DISABLE KEYS */;
+INSERT INTO `truncate_semicolon_case` VALUES (1,'alpha;beta');
+/*!40000 ALTER TABLE `truncate_semicolon_case` ENABLE KEYS */;
+UNLOCK TABLES;

--- a/tests/issue_semicolon_truncate_anon.sql
+++ b/tests/issue_semicolon_truncate_anon.sql
@@ -1,0 +1,19 @@
+DROP TABLE IF EXISTS `truncate_semicolon_case`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!50503 SET character_set_client = utf8mb4 */;
+CREATE TABLE `truncate_semicolon_case` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `note` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping data for table `truncate_semicolon_case`
+--
+
+LOCK TABLES `truncate_semicolon_case` WRITE;
+/*!40000 ALTER TABLE `truncate_semicolon_case` DISABLE KEYS */;
+
+/*!40000 ALTER TABLE `truncate_semicolon_case` ENABLE KEYS */;
+UNLOCK TABLES;


### PR DESCRIPTION
## Summary

Fix truncate-mode handling for `INSERT`/`REPLACE` statements that contain semicolons inside quoted SQL string values.

## Bug

When a table is configured for truncation, the scanner skips input until it sees `;`.  
That incorrectly treats semicolons inside quoted values as statement terminators, which can cause the tail of a truncated row to leak into the output.

## Fix

While in `ST_TRUNCATE_SKIP`, the scanner now consumes quoted string literals as a whole, including normal single-quoted strings and `_binary '...'` strings. This ensures only a real statement terminator outside a quoted value ends the skip.